### PR TITLE
fix: correct SendGrid SMTP/TLS configuration - Fix 'Connection alread…

### DIFF
--- a/src/notifications/emails.py
+++ b/src/notifications/emails.py
@@ -55,15 +55,39 @@ class EmailSender(EmailSenderInterface):
         message.attach(MIMEText(html_content, "html"))
 
         try:
-            # For MailHog (development/testing), we don't need authentication
-            smtp = aiosmtplib.SMTP(hostname=self._hostname, port=self._port)
-            await smtp.connect()
+            # Configure SMTP connection based on service
+            if self._hostname == "mailhog":
+                # MailHog (development) - no encryption, no auth
+                smtp = aiosmtplib.SMTP(hostname=self._hostname, port=self._port)
+                await smtp.connect()
+                
+            elif self._hostname == "smtp.sendgrid.net":
+                # SendGrid specific configuration
+                if self._port == 587:
+                    # Use STARTTLS for port 587
+                    smtp = aiosmtplib.SMTP(hostname=self._hostname, port=self._port)
+                    await smtp.connect()
+                    await smtp.starttls()
+                elif self._port == 465:
+                    # Use SSL/TLS for port 465
+                    smtp = aiosmtplib.SMTP(hostname=self._hostname, port=self._port, use_tls=True)
+                    await smtp.connect()
+                else:
+                    # Fallback for other ports
+                    smtp = aiosmtplib.SMTP(hostname=self._hostname, port=self._port)
+                    await smtp.connect()
+                    if self._use_tls:
+                        await smtp.starttls()
+                        
+            else:
+                # Generic SMTP configuration
+                smtp = aiosmtplib.SMTP(hostname=self._hostname, port=self._port)
+                await smtp.connect()
+                
+                if self._use_tls:
+                    await smtp.starttls()
 
-            # Only use TLS and login if configured
-            if self._use_tls and self._hostname != "mailhog":
-                await smtp.starttls()
-
-            # Only login if credentials are provided and not using MailHog
+            # Login with credentials if provided and not MailHog
             if self._email and self._password and self._hostname != "mailhog":
                 await smtp.login(self._email, self._password)
 


### PR DESCRIPTION
…y using TLS' error for SendGrid - Add proper STARTTLS handling for port 587 - Support both port 587 (STARTTLS) and port 465 (SSL/TLS) - Maintain MailHog compatibility for development - Resolve email sending failures permanently