### PR TITLE
fix: use start_tls parameter for SendGrid port 587 - Replace manual s…

### DIFF
--- a/src/notifications/emails.py
+++ b/src/notifications/emails.py
@@ -64,10 +64,13 @@ class EmailSender(EmailSenderInterface):
             elif self._hostname == "smtp.sendgrid.net":
                 # SendGrid specific configuration
                 if self._port == 587:
-                    # Use STARTTLS for port 587
-                    smtp = aiosmtplib.SMTP(hostname=self._hostname, port=self._port)
+                    # Use start_tls=True for port 587 (avoids double TLS)
+                    smtp = aiosmtplib.SMTP(
+                        hostname=self._hostname, 
+                        port=self._port,
+                        start_tls=True  # This handles STARTTLS automatically
+                    )
                     await smtp.connect()
-                    await smtp.starttls()
                 elif self._port == 465:
                     # Use SSL/TLS for port 465
                     smtp = aiosmtplib.SMTP(hostname=self._hostname, port=self._port, use_tls=True)


### PR DESCRIPTION
…tarttls() call with start_tls=True parameter - Avoid 'Connection already using TLS' error - Let aiosmtplib handle STARTTLS automatically for SendGrid - Final fix for email sending issues