### PR TITLE
fix: separate SMTP username from sender email address - Add EMAIL_FRO…

### DIFF
--- a/src/config/dependencies.py
+++ b/src/config/dependencies.py
@@ -76,8 +76,9 @@ def get_email_sender(
     return EmailSender(
         hostname=settings.EMAIL_HOST,
         port=settings.EMAIL_PORT,
-        email=settings.EMAIL_HOST_USER,
+        username=settings.EMAIL_HOST_USER,
         password=settings.EMAIL_HOST_PASSWORD,
+        sender_email=settings.EMAIL_FROM,
         use_tls=settings.EMAIL_USE_TLS,
         template_dir="src/templates/email",
         activation_email_template_name="activation.html",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -19,6 +19,7 @@ class BaseAppSettings(BaseSettings):
     EMAIL_HOST_USER: str = os.getenv("EMAIL_HOST_USER", "")
     EMAIL_HOST_PASSWORD: str = os.getenv("EMAIL_HOST_PASSWORD", "")
     EMAIL_USE_TLS: bool = os.getenv("EMAIL_USE_TLS", "False").lower() == "true"
+    EMAIL_FROM: str = os.getenv("EMAIL_FROM", "noreply@cinema.local")
 
     # MinIO settings
     MINIO_HOST: str = os.getenv("MINIO_HOST", "minio")

--- a/src/management/commands/test_email.py
+++ b/src/management/commands/test_email.py
@@ -43,8 +43,9 @@ async def test_email_direct() -> None:
     email_sender = EmailSender(
         hostname=settings.EMAIL_HOST,
         port=settings.EMAIL_PORT,
-        email=settings.EMAIL_HOST_USER,
+        username=settings.EMAIL_HOST_USER,
         password=settings.EMAIL_HOST_PASSWORD,
+        sender_email=settings.EMAIL_FROM,
         use_tls=settings.EMAIL_USE_TLS,
         template_dir="src/templates/email",
         activation_email_template_name="activation.html",

--- a/src/notifications/emails.py
+++ b/src/notifications/emails.py
@@ -15,8 +15,9 @@ class EmailSender(EmailSenderInterface):
         self,
         hostname: str,
         port: int,
-        email: str,
+        username: str,
         password: str,
+        sender_email: str,
         use_tls: bool,
         template_dir: str,
         activation_email_template_name: str,
@@ -26,8 +27,9 @@ class EmailSender(EmailSenderInterface):
     ):
         self._hostname = hostname
         self._port = port
-        self._email = email
+        self._username = username  # For SMTP auth (e.g. "apikey")
         self._password = password
+        self._sender_email = sender_email  # For From header (e.g. "noreply@fast-furious.work.gd")
         self._use_tls = use_tls
         self._activation_email_template_name = activation_email_template_name
         self._activation_complete_email_template_name = activation_complete_email_template_name
@@ -49,7 +51,7 @@ class EmailSender(EmailSenderInterface):
             BaseEmailError: If sending the email fails.
         """
         message = MIMEMultipart()
-        message["From"] = self._email
+        message["From"] = self._sender_email  # Use sender_email instead of username
         message["To"] = recipient
         message["Subject"] = subject
         message.attach(MIMEText(html_content, "html"))
@@ -91,10 +93,10 @@ class EmailSender(EmailSenderInterface):
                     await smtp.starttls()
 
             # Login with credentials if provided and not MailHog
-            if self._email and self._password and self._hostname != "mailhog":
-                await smtp.login(self._email, self._password)
+            if self._username and self._password and self._hostname != "mailhog":
+                await smtp.login(self._username, self._password)
 
-            await smtp.sendmail(self._email, [recipient], message.as_string())
+            await smtp.sendmail(self._sender_email, [recipient], message.as_string())
             await smtp.quit()
 
             logging.info(f"Email sent successfully to {recipient}")

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -55,8 +55,9 @@ def get_email_sender():
     return EmailSender(
         hostname=settings.EMAIL_HOST,
         port=settings.EMAIL_PORT,
-        email=settings.EMAIL_HOST_USER,
+        username=settings.EMAIL_HOST_USER,
         password=settings.EMAIL_HOST_PASSWORD,
+        sender_email=settings.EMAIL_FROM,
         use_tls=settings.EMAIL_USE_TLS,
         template_dir="src/templates/email",
         activation_email_template_name="activation.html",


### PR DESCRIPTION
…M setting for sender email address - Separate SMTP auth (username) from email From header (sender_email) - Fix SendGrid verified sender identity error - Support both domain and single sender verification - Update all email-related components with new structure