### PR TITLE
fix: Add missing CommentModel import to models/__init__.py - Resolve …

### DIFF
--- a/src/database/models/__init__.py
+++ b/src/database/models/__init__.py
@@ -1,6 +1,7 @@
 # src/database/models/__init__.py
 from src.database.models.accounts import *
 from src.database.models.cart import *
+from src.database.models.comment import *
 from src.database.models.movies import *
 from src.database.models.orders import *
 from src.database.models.payments import *


### PR DESCRIPTION
…ImportError preventing server startup - CommentModel was defined but not exported from models package