### PR TITLE
fix: Change default admin email from cinema.local to example.com - Fi…

### DIFF
--- a/src/management/commands/init_default_data.py
+++ b/src/management/commands/init_default_data.py
@@ -116,7 +116,7 @@ async def create_default_admin(db: AsyncSession) -> None:
         return
     
     # Default admin credentials
-    DEFAULT_ADMIN_EMAIL = "admin@cinema.local"
+    DEFAULT_ADMIN_EMAIL = "admin@example.com"
     DEFAULT_ADMIN_PASSWORD = "CinemaAdmin2024!"
     
     try:


### PR DESCRIPTION
…x email validation error: .local is reserved domain - Default admin now: admin@example.com / CinemaAdmin2024!